### PR TITLE
feat: enforce json:api serialization standards only when accept heade…

### DIFF
--- a/src/JsonApiDotNetCore/Formatters/JsonApiOutputFormatter.cs
+++ b/src/JsonApiDotNetCore/Formatters/JsonApiOutputFormatter.cs
@@ -13,9 +13,9 @@ namespace JsonApiDotNetCore.Formatters
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            var contentTypeString = context.HttpContext.Request.ContentType;
+            var acceptString = context.HttpContext.Request.Headers["Accept"];
 
-            return string.IsNullOrEmpty(contentTypeString) || contentTypeString == Constants.ContentType;
+            return acceptString == Constants.ContentType;
         }
 
         public async Task WriteAsync(OutputFormatterWriteContext context)

--- a/src/JsonApiDotNetCore/Formatters/JsonApiOutputFormatter.cs
+++ b/src/JsonApiDotNetCore/Formatters/JsonApiOutputFormatter.cs
@@ -13,7 +13,7 @@ namespace JsonApiDotNetCore.Formatters
             if (context == null)
                 throw new ArgumentNullException(nameof(context));
 
-            var acceptString = context.HttpContext.Request.Headers["Accept"];
+            var acceptString = context.HttpContext.Request.Headers[Constants.AcceptHeader];
 
             return acceptString == Constants.ContentType;
         }


### PR DESCRIPTION
We would like to fall back to our default json serialization configuration when the request does not specify the string "application/vnd.api+json" for a requests "Accept" header.