### PR TITLE
feat: fix error handling

### DIFF
--- a/src/JsonApiDotNetCore/Middleware/JsonApiExceptionFilter.cs
+++ b/src/JsonApiDotNetCore/Middleware/JsonApiExceptionFilter.cs
@@ -16,6 +16,9 @@ namespace JsonApiDotNetCore.Middleware
 
         public void OnException(ExceptionContext context)
         {
+            if (context.HttpContext.Request.Headers[Constants.AcceptHeader] != Constants.ContentType)
+                return;
+
             _logger?.LogError(new EventId(), context.Exception, "An unhandled exception occurred during the request");
 
             var jsonApiException = JsonApiExceptionFactory.GetException(context.Exception);


### PR DESCRIPTION
Default to custom error handling if request doesnt have the json:api accept type